### PR TITLE
More accurate exceptions + get user tenants from the PDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For [Maven](https://maven.apache.org/) projects, use:
 <dependency>
   <groupId>io.permit</groupId>
   <artifactId>permit-sdk-java</artifactId>
-  <version>1.4.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
@@ -24,7 +24,7 @@ For [Gradle](https://gradle.org/) projects, configure `permit-sdk-java` as a dep
 dependencies {
     // ...
 
-    implementation 'io.permit:permit-sdk-java:1.4.0'
+    implementation 'io.permit:permit-sdk-java:2.0.0'
 }
 ```
 
@@ -148,6 +148,6 @@ CreateOrUpdateResult<UserRead> result = permit.api.users.sync(new UserCreate("[U
 
 ## Javadoc reference
 
-To view the javadoc reference, [click here](https://javadoc.io/doc/io.permit/permit-sdk-java/1.4.0/index.html).
+To view the javadoc reference, [click here](https://javadoc.io/doc/io.permit/permit-sdk-java/2.0.0/index.html).
 
-It's easiest to start with the root [Permit](https://javadoc.io/static/io.permit/permit-sdk-java/1.4.0/io/permit/sdk/Permit.html) class.
+It's easiest to start with the root [Permit](https://javadoc.io/static/io.permit/permit-sdk-java/2.0.0/io/permit/sdk/Permit.html) class.

--- a/src/main/java/io/permit/sdk/Permit.java
+++ b/src/main/java/io/permit/sdk/Permit.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.permit.sdk.api.ApiClient;
 import io.permit.sdk.api.ElementsApi;
+import io.permit.sdk.api.PermitApiError;
 import io.permit.sdk.enforcement.*;
 import io.permit.sdk.util.Context;
 
@@ -107,7 +108,7 @@ public class Permit implements IEnforcerApi {
      * @throws IOException if an error occurs while checking the authorization.
      */
     @Override
-    public boolean check(User user, String action, Resource resource, Context context) throws IOException {
+    public boolean check(User user, String action, Resource resource, Context context) throws IOException, PermitApiError {
         return this.enforcer.check(user, action, resource, context);
     }
 
@@ -122,37 +123,37 @@ public class Permit implements IEnforcerApi {
      * @throws IOException if an error occurs while checking the authorization.
      */
     @Override
-    public boolean check(User user, String action, Resource resource) throws IOException {
+    public boolean check(User user, String action, Resource resource) throws IOException, PermitApiError {
         return this.enforcer.check(user, action, resource);
     }
 
     @Override
-    public boolean checkUrl(User user, String httpMethod, String url, String tenant, Context context) throws IOException {
+    public boolean checkUrl(User user, String httpMethod, String url, String tenant, Context context) throws IOException, PermitApiError {
         return this.enforcer.checkUrl(user, httpMethod, url, tenant, context);
     }
 
     @Override
-    public boolean checkUrl(User user, String httpMethod, String url, String tenant) throws IOException {
+    public boolean checkUrl(User user, String httpMethod, String url, String tenant) throws IOException, PermitApiError {
         return this.enforcer.checkUrl(user, httpMethod, url, tenant);
     }
 
     @Override
-    public boolean[] bulkCheck(List<CheckQuery> checks) throws IOException {
+    public boolean[] bulkCheck(List<CheckQuery> checks) throws IOException, PermitApiError {
         return this.enforcer.bulkCheck(checks);
     }
 
     @Override
-    public List<TenantDetails> checkInAllTenants(User user, String action, Resource resource, Context context) throws IOException {
+    public List<TenantDetails> checkInAllTenants(User user, String action, Resource resource, Context context) throws IOException, PermitApiError {
         return this.enforcer.checkInAllTenants(user, action, resource, context);
     }
 
     @Override
-    public List<TenantDetails> checkInAllTenants(User user, String action, Resource resource) throws IOException {
+    public List<TenantDetails> checkInAllTenants(User user, String action, Resource resource) throws IOException, PermitApiError {
         return this.enforcer.checkInAllTenants(user, action, resource);
     }
 
     @Override
-    public UserPermissions getUserPermissions(GetUserPermissionsQuery input) throws IOException {
+    public UserPermissions getUserPermissions(GetUserPermissionsQuery input) throws IOException, PermitApiError {
         return this.enforcer.getUserPermissions(input);
     }
 }

--- a/src/main/java/io/permit/sdk/Permit.java
+++ b/src/main/java/io/permit/sdk/Permit.java
@@ -105,7 +105,8 @@ public class Permit implements IEnforcerApi {
      * @param resource The resource object representing the resource.
      * @param context  The context object representing the context in which the action is performed.
      * @return {@code true} if the user is authorized, {@code false} otherwise.
-     * @throws IOException if an error occurs while checking the authorization.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     @Override
     public boolean check(User user, String action, Resource resource, Context context) throws IOException, PermitApiError {
@@ -120,7 +121,8 @@ public class Permit implements IEnforcerApi {
      * @param action   The action to be performed on the resource.
      * @param resource The resource object representing the resource.
      * @return {@code true} if the user is authorized, {@code false} otherwise.
-     * @throws IOException if an error occurs while checking the authorization.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     @Override
     public boolean check(User user, String action, Resource resource) throws IOException, PermitApiError {

--- a/src/main/java/io/permit/sdk/Permit.java
+++ b/src/main/java/io/permit/sdk/Permit.java
@@ -160,7 +160,12 @@ public class Permit implements IEnforcerApi {
     }
 
     @Override
-    public List<TenantDetails> getUserTenants(GetUserTenantsQuery input) throws IOException, PermitApiError {
-        return this.enforcer.getUserTenants(input);
+    public List<TenantDetails> getUserTenants(User user, Context context) throws IOException, PermitApiError {
+        return this.enforcer.getUserTenants(user, context);
+    }
+
+    @Override
+    public List<TenantDetails> getUserTenants(User user) throws IOException, PermitApiError {
+        return this.enforcer.getUserTenants(user);
     }
 }

--- a/src/main/java/io/permit/sdk/Permit.java
+++ b/src/main/java/io/permit/sdk/Permit.java
@@ -156,4 +156,9 @@ public class Permit implements IEnforcerApi {
     public UserPermissions getUserPermissions(GetUserPermissionsQuery input) throws IOException, PermitApiError {
         return this.enforcer.getUserPermissions(input);
     }
+
+    @Override
+    public List<TenantDetails> getUserTenants(GetUserTenantsQuery input) throws IOException, PermitApiError {
+        return this.enforcer.getUserTenants(input);
+    }
 }

--- a/src/main/java/io/permit/sdk/enforcement/Enforcer.java
+++ b/src/main/java/io/permit/sdk/enforcement/Enforcer.java
@@ -448,8 +448,7 @@ public class Enforcer implements IEnforcerApi {
         return result;
     }
 
-    @Override
-    public List<TenantDetails> getUserTenants(GetUserTenantsQuery input) throws IOException, PermitApiError {
+    private List<TenantDetails> getUserTenants(GetUserTenantsQuery input) throws IOException, PermitApiError {
         // request body
         Gson gson = new Gson();
         String requestBody = gson.toJson(input);
@@ -480,6 +479,16 @@ public class Enforcer implements IEnforcerApi {
             ));
         }
         return tenants;
+    }
+
+    @Override
+    public List<TenantDetails> getUserTenants(User user) throws IOException, PermitApiError {
+        return this.getUserTenants(new GetUserTenantsQuery(user));
+    }
+
+    @Override
+    public List<TenantDetails> getUserTenants(User user, Context context) throws IOException, PermitApiError {
+        return this.getUserTenants(new GetUserTenantsQuery(user, context));
     }
 
     @Override

--- a/src/main/java/io/permit/sdk/enforcement/Enforcer.java
+++ b/src/main/java/io/permit/sdk/enforcement/Enforcer.java
@@ -261,7 +261,8 @@ public class Enforcer implements IEnforcerApi {
     * @param action   The action to be performed.
     * @param resource The resource on which the action is performed.
     * @return {@code true} if the user is allowed to perform the action, {@code false} otherwise.
-    * @throws IOException If an error occurs during the authorization check.
+    * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+    * @throws IOException if could not read the content of the returned http response.
     */
     @Override
     public boolean check(User user, String action, Resource resource) throws IOException, PermitApiError {

--- a/src/main/java/io/permit/sdk/enforcement/GetUserTenantsQuery.java
+++ b/src/main/java/io/permit/sdk/enforcement/GetUserTenantsQuery.java
@@ -1,0 +1,22 @@
+package io.permit.sdk.enforcement;
+
+import io.permit.sdk.util.Context;
+
+public final class GetUserTenantsQuery {
+    public final User user;
+    public final Context context;
+
+    /**
+     * input to get user tenants api
+     *
+     * @param user              the user we'd like to get a list of permissions for.
+     * @param context  The context for the authorization check.
+     */
+    public GetUserTenantsQuery(User user, Context context) {
+        this.user = user;
+        this.context = context;
+    }
+    public GetUserTenantsQuery(User user) {
+        this(user, new Context());
+    }
+}

--- a/src/main/java/io/permit/sdk/enforcement/IEnforcerApi.java
+++ b/src/main/java/io/permit/sdk/enforcement/IEnforcerApi.java
@@ -115,10 +115,21 @@ public interface IEnforcerApi {
     /**
      * list all the tenants the user is associated with.
      *
-     * @param input input to get user tenants api
+     * @param user The user object representing the user.
+     * @param context  additional context to OPA
      * @return List of TenantDetails objects, representing the tenants in which the action is allowed.
      * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
      * @throws IOException if could not read the content of the returned http response.
      */
-    List<TenantDetails> getUserTenants(GetUserTenantsQuery input) throws IOException, PermitApiError;
+    List<TenantDetails> getUserTenants(User user, Context context) throws IOException, PermitApiError;
+
+    /**
+     * list all the tenants the user is associated with.
+     *
+     * @param user The user object representing the user.
+     * @return List of TenantDetails objects, representing the tenants in which the action is allowed.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
+     */
+    List<TenantDetails> getUserTenants(User user) throws IOException, PermitApiError;
 }

--- a/src/main/java/io/permit/sdk/enforcement/IEnforcerApi.java
+++ b/src/main/java/io/permit/sdk/enforcement/IEnforcerApi.java
@@ -15,7 +15,8 @@ public interface IEnforcerApi {
      * @param resource The resource object representing the resource.
      * @param context The context object representing the context in which the action is performed.
      * @return `true` if the user is authorized, `false` otherwise.
-     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     boolean check(User user, String action, Resource resource, Context context) throws IOException, PermitApiError;
 
@@ -26,7 +27,8 @@ public interface IEnforcerApi {
      * @param action The action to be performed on the resource.
      * @param resource The resource object representing the resource.
      * @return `true` if the user is authorized, `false` otherwise.
-     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     boolean check(User user, String action, Resource resource) throws IOException, PermitApiError;
 
@@ -40,7 +42,8 @@ public interface IEnforcerApi {
      * @param url the url the user is calling, typically determines the resource.
      * @param tenant the tenant determines the scope of the permission check.
      * @return `true` if the user is authorized, `false` otherwise.
-     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     boolean checkUrl(User user, String httpMethod, String url, String tenant) throws IOException, PermitApiError;
 
@@ -56,7 +59,8 @@ public interface IEnforcerApi {
      * @param tenant the tenant determines the scope of the permission check.
      * @param context The context object representing the context in which the action is performed.
      * @return `true` if the user is authorized, `false` otherwise.
-     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     boolean checkUrl(User user, String httpMethod, String url, String tenant, Context context) throws IOException, PermitApiError;
 
@@ -65,7 +69,8 @@ public interface IEnforcerApi {
      *
      * @param checks The check requests, each containing user, action, resource and context.
      * @return array containing `true` if the user is authorized, `false` otherwise for each check request.
-     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     boolean[] bulkCheck(List<CheckQuery> checks) throws IOException, PermitApiError;
 
@@ -78,7 +83,8 @@ public interface IEnforcerApi {
      * @param resource The resource object representing the resource.
      * @param context  The context object representing the context in which the action is performed.
      * @return List of TenantDetails objects, representing the tenants in which the action is allowed.
-     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     List<TenantDetails> checkInAllTenants(User user, String action, Resource resource, Context context) throws IOException, PermitApiError;
 
@@ -91,7 +97,8 @@ public interface IEnforcerApi {
      * @param action The action to be performed on the resource.
      * @param resource The resource object representing the resource.
      * @return List of TenantDetails objects, representing the tenants in which the action is allowed.
-     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     List<TenantDetails> checkInAllTenants(User user, String action, Resource resource) throws IOException, PermitApiError;
 
@@ -100,7 +107,8 @@ public interface IEnforcerApi {
      *
      * @param input input to get user permissions api
      * @return A UserPermissions object, that contains all the permissions granted to the user.
-     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     UserPermissions getUserPermissions(GetUserPermissionsQuery input) throws IOException, PermitApiError;
 
@@ -109,7 +117,8 @@ public interface IEnforcerApi {
      *
      * @param input input to get user tenants api
      * @return List of TenantDetails objects, representing the tenants in which the action is allowed.
-     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     * @throws PermitApiError if an error occurs while sending the authorization request to the PDP.
+     * @throws IOException if could not read the content of the returned http response.
      */
     List<TenantDetails> getUserTenants(GetUserTenantsQuery input) throws IOException, PermitApiError;
 }

--- a/src/main/java/io/permit/sdk/enforcement/IEnforcerApi.java
+++ b/src/main/java/io/permit/sdk/enforcement/IEnforcerApi.java
@@ -1,5 +1,6 @@
 package io.permit.sdk.enforcement;
 
+import io.permit.sdk.api.PermitApiError;
 import io.permit.sdk.util.Context;
 
 import java.io.IOException;
@@ -16,7 +17,7 @@ public interface IEnforcerApi {
      * @return `true` if the user is authorized, `false` otherwise.
      * @throws IOException if an error occurs while sending the authorization request to the PDP.
      */
-    boolean check(User user, String action, Resource resource, Context context) throws IOException;
+    boolean check(User user, String action, Resource resource, Context context) throws IOException, PermitApiError;
 
     /**
      * Checks if a `user` is authorized to perform an `action` on a `resource` without additional context
@@ -27,7 +28,7 @@ public interface IEnforcerApi {
      * @return `true` if the user is authorized, `false` otherwise.
      * @throws IOException if an error occurs while sending the authorization request to the PDP.
      */
-    boolean check(User user, String action, Resource resource) throws IOException;
+    boolean check(User user, String action, Resource resource) throws IOException, PermitApiError;
 
     /**
      * Performs a permission check on a (resource, action) pair that are represented by an HTTP endpoint.
@@ -41,7 +42,7 @@ public interface IEnforcerApi {
      * @return `true` if the user is authorized, `false` otherwise.
      * @throws IOException if an error occurs while sending the authorization request to the PDP.
      */
-    boolean checkUrl(User user, String httpMethod, String url, String tenant) throws IOException;
+    boolean checkUrl(User user, String httpMethod, String url, String tenant) throws IOException, PermitApiError;
 
     /**
      * Performs a permission check on a (resource, action) pair that are represented by an HTTP endpoint.
@@ -57,7 +58,7 @@ public interface IEnforcerApi {
      * @return `true` if the user is authorized, `false` otherwise.
      * @throws IOException if an error occurs while sending the authorization request to the PDP.
      */
-    boolean checkUrl(User user, String httpMethod, String url, String tenant, Context context) throws IOException;
+    boolean checkUrl(User user, String httpMethod, String url, String tenant, Context context) throws IOException, PermitApiError;
 
     /**
      * Runs multiple permission checks in a single HTTP Request (Bulk Check).
@@ -66,7 +67,7 @@ public interface IEnforcerApi {
      * @return array containing `true` if the user is authorized, `false` otherwise for each check request.
      * @throws IOException if an error occurs while sending the authorization request to the PDP.
      */
-    boolean[] bulkCheck(List<CheckQuery> checks) throws IOException;
+    boolean[] bulkCheck(List<CheckQuery> checks) throws IOException, PermitApiError;
 
     /**
      * Checks if a `user` is authorized to perform an `action` on a `resource` (with `context`) across all tenants.
@@ -79,7 +80,7 @@ public interface IEnforcerApi {
      * @return List of TenantDetails objects, representing the tenants in which the action is allowed.
      * @throws IOException if an error occurs while sending the authorization request to the PDP.
      */
-    List<TenantDetails> checkInAllTenants(User user, String action, Resource resource, Context context) throws IOException;
+    List<TenantDetails> checkInAllTenants(User user, String action, Resource resource, Context context) throws IOException, PermitApiError;
 
     /**
      * Checks if a `user` is authorized to perform an `action` on a `resource` across all tenants,
@@ -92,7 +93,7 @@ public interface IEnforcerApi {
      * @return List of TenantDetails objects, representing the tenants in which the action is allowed.
      * @throws IOException if an error occurs while sending the authorization request to the PDP.
      */
-    List<TenantDetails> checkInAllTenants(User user, String action, Resource resource) throws IOException;
+    List<TenantDetails> checkInAllTenants(User user, String action, Resource resource) throws IOException, PermitApiError;
 
     /**
      * list all the permissions granted to a user (by default in all tenants and for all objects).
@@ -101,5 +102,5 @@ public interface IEnforcerApi {
      * @return A UserPermissions object, that contains all the permissions granted to the user.
      * @throws IOException if an error occurs while sending the authorization request to the PDP.
      */
-    UserPermissions getUserPermissions(GetUserPermissionsQuery input) throws IOException;
+    UserPermissions getUserPermissions(GetUserPermissionsQuery input) throws IOException, PermitApiError;
 }

--- a/src/main/java/io/permit/sdk/enforcement/IEnforcerApi.java
+++ b/src/main/java/io/permit/sdk/enforcement/IEnforcerApi.java
@@ -103,4 +103,13 @@ public interface IEnforcerApi {
      * @throws IOException if an error occurs while sending the authorization request to the PDP.
      */
     UserPermissions getUserPermissions(GetUserPermissionsQuery input) throws IOException, PermitApiError;
+
+    /**
+     * list all the tenants the user is associated with.
+     *
+     * @param input input to get user tenants api
+     * @return List of TenantDetails objects, representing the tenants in which the action is allowed.
+     * @throws IOException if an error occurs while sending the authorization request to the PDP.
+     */
+    List<TenantDetails> getUserTenants(GetUserTenantsQuery input) throws IOException, PermitApiError;
 }

--- a/src/main/java/io/permit/sdk/enforcement/ObjectPermissions.java
+++ b/src/main/java/io/permit/sdk/enforcement/ObjectPermissions.java
@@ -10,10 +10,12 @@ public class ObjectPermissions {
     public final TenantDetails tenant;
     public final ResourceDetails resource;
     public final List<String> permissions;
+    public final List<String> roles;
 
-    public ObjectPermissions(TenantDetails tenant, ResourceDetails resource, List<String> permissions) {
+    public ObjectPermissions(TenantDetails tenant, ResourceDetails resource, List<String> permissions, List<String> roles) {
         this.tenant = tenant;
         this.resource = resource;
         this.permissions = permissions;
+        this.roles = roles;
     }
 }

--- a/src/test/java/io/permit/sdk/e2e/RbacE2ETest.java
+++ b/src/test/java/io/permit/sdk/e2e/RbacE2ETest.java
@@ -258,6 +258,16 @@ public class RbacE2ETest extends PermitE2ETestBase {
             assertTrue(permissions.get(tenantObjectKey).permissions.contains("document:read"));
             assertTrue(permissions.get(tenant2ObjectKey).permissions.contains("document:create"));
 
+            logger.info("testing 'get user tenants' on user 'elon'");
+            List<TenantDetails> userTenants = permit.getUserTenants(
+                    User.fromString("auth0|elon")
+            );
+            assertEquals(userTenants.size(), 2);
+            assertTrue(userTenants.get(0).key.equals(tenant.key) || userTenants.get(0).key.equals(tenant2.key));
+            assertTrue(userTenants.get(1).key.equals(tenant.key) || userTenants.get(1).key.equals(tenant2.key));
+            assertNotEquals(userTenants.get(0).key, userTenants.get(1).key);
+
+
             // change the user role
             permit.api.users.assignRole(user.key, admin.key, tenant.key);
             permit.api.users.unassignRole(user.key, viewer.key, tenant.key);


### PR DESCRIPTION
- Throw more accurate exceptions in case OPA or the PDP return an error response or timeout
- get user tenants from the PDP
- get user permissions from the PDP now returns roles as well